### PR TITLE
feature (office): add pageable & sortable List Offices API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,43 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.7</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.stevanrose</groupId>
-	<artifactId>spring-boot-carbon-two</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>spring-boot-carbon-two</name>
-	<description>Demo REST CRUD project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.7</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>com.stevanrose</groupId>
+    <artifactId>spring-boot-carbon-two</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>spring-boot-carbon-two</name>
+    <description>Demo REST CRUD project for Spring Boot</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
@@ -48,11 +48,11 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
@@ -71,34 +71,34 @@
             <scope>provided</scope>
         </dependency>
 
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-	</dependencies>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
                         <path>
                             <groupId>org.mapstruct</groupId>
                             <artifactId>mapstruct-processor</artifactId>
@@ -109,22 +109,22 @@
                             <artifactId>lombok-mapstruct-binding</artifactId>
                             <version>0.2.0</version>
                         </path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/com/stevanrose/carbon_two/Application.java
+++ b/src/main/java/com/stevanrose/carbon_two/Application.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 
 }

--- a/src/main/java/com/stevanrose/carbon_two/common/paging/PageResponse.java
+++ b/src/main/java/com/stevanrose/carbon_two/common/paging/PageResponse.java
@@ -1,0 +1,13 @@
+package com.stevanrose.carbon_two.common.paging;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(List<T> content, int page, int size, long totalElements, int totalPages) {
+
+    public static <T> PageResponse<T> of(Page<T> p) {
+        return new PageResponse<>(p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
+    }
+
+}

--- a/src/main/java/com/stevanrose/carbon_two/office/controller/OfficeController.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/controller/OfficeController.java
@@ -1,17 +1,22 @@
 package com.stevanrose.carbon_two.office.controller;
 
+import com.stevanrose.carbon_two.common.paging.PageResponse;
 import com.stevanrose.carbon_two.office.domain.Office;
 import com.stevanrose.carbon_two.office.service.OfficeService;
-import com.stevanrose.carbon_two.office.web.dto.mapper.OfficeMapper;
+import com.stevanrose.carbon_two.office.web.dto.OfficePageResponse;
 import com.stevanrose.carbon_two.office.web.dto.OfficeRequest;
 import com.stevanrose.carbon_two.office.web.dto.OfficeResponse;
+import com.stevanrose.carbon_two.office.web.dto.mapper.OfficeMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
@@ -21,6 +26,14 @@ public class OfficeController {
 
     private final OfficeService officeService;
     private final OfficeMapper officeMapper;
+
+    @GetMapping
+    @Operation(summary = "List Offices", description = "Retrieve a paginated list of offices.")
+    @ApiResponse(responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = OfficePageResponse.class)))
+    public PageResponse<OfficeResponse> list(@ParameterObject Pageable pageable) {
+        var page = officeService.list(pageable).map(officeMapper::toResponse);
+        return PageResponse.of(page);
+    }
 
     @PostMapping
     public ResponseEntity<OfficeResponse> create(@Valid @RequestBody OfficeRequest request, UriComponentsBuilder uri) {

--- a/src/main/java/com/stevanrose/carbon_two/office/repository/OfficeRepository.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/repository/OfficeRepository.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public interface OfficeRepository extends JpaRepository<Office, UUID> {
 
     Optional<Office> findByCodeIgnoreCase(String code);
+
     boolean existsByCodeIgnoreCase(String code);
 
 }

--- a/src/main/java/com/stevanrose/carbon_two/office/service/OfficeService.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/service/OfficeService.java
@@ -3,6 +3,8 @@ package com.stevanrose.carbon_two.office.service;
 import com.stevanrose.carbon_two.office.domain.Office;
 import com.stevanrose.carbon_two.office.repository.OfficeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class OfficeService {
 
     private final OfficeRepository officeRepository;
+
+    @Transactional(readOnly = true)
+    public Page<Office> list(Pageable pageable) {
+        return officeRepository.findAll(pageable);
+    }
 
     @Transactional
     public Office create(Office office) {

--- a/src/main/java/com/stevanrose/carbon_two/office/web/dto/OfficePageResponse.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/web/dto/OfficePageResponse.java
@@ -1,0 +1,14 @@
+package com.stevanrose.carbon_two.office.web.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "OfficePageResponse", description = "Paginated response for Office entities")
+public class OfficePageResponse {
+    @ArraySchema(schema = @Schema(implementation = OfficeResponse.class))
+    private java.util.List<OfficeResponse> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+}

--- a/src/main/java/com/stevanrose/carbon_two/office/web/dto/mapper/OfficeMapper.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/web/dto/mapper/OfficeMapper.java
@@ -3,13 +3,15 @@ package com.stevanrose.carbon_two.office.web.dto.mapper;
 import com.stevanrose.carbon_two.office.domain.Office;
 import com.stevanrose.carbon_two.office.web.dto.OfficeRequest;
 import com.stevanrose.carbon_two.office.web.dto.OfficeResponse;
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(componentModel = "spring",
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface OfficeMapper {
 
     Office toEntity(OfficeRequest request);
+
     OfficeResponse toResponse(Office office);
 //    void update(@MappingTarget Office office, OfficeRequest request);
 

--- a/src/main/resources/db/changelog/changelog-master.json
+++ b/src/main/resources/db/changelog/changelog-master.json
@@ -2,7 +2,7 @@
   "databaseChangeLog": [
     {
       "include": {
-        "file": "db/changelog/000-extensions.json",
+        "file": "db/changelog/000-extensions.json"
       }
     },
     {

--- a/src/test/java/com/stevanrose/carbon_two/ApplicationTests.java
+++ b/src/test/java/com/stevanrose/carbon_two/ApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class ApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/OfficeControllerTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/OfficeControllerTest.java
@@ -1,7 +1,6 @@
 package com.stevanrose.carbon_two.office.controller;
 
 import com.stevanrose.carbon_two.office.repository.OfficeRepository;
-import com.stevanrose.carbon_two.office.web.dto.OfficeRequest;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,12 +25,12 @@ class OfficeControllerTest {
     @BeforeEach
     void setUp() {
         officeRepository.deleteAll();
+
     }
 
     @SneakyThrows
     @Test
     void shouldCreateOffice() {
-
 
         String reqJson = """
                     {
@@ -44,8 +43,8 @@ class OfficeControllerTest {
                 """;
 
         mockMvc.perform(post("/api/offices")
-                .contentType("application/json")
-                .content(reqJson))
+                        .contentType("application/json")
+                        .content(reqJson))
                 .andExpect(status().isCreated());
 
     }

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerCreateWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerCreateWebTest.java
@@ -1,5 +1,6 @@
-package com.stevanrose.carbon_two.office.controller;
+package com.stevanrose.carbon_two.office.controller.slice;
 
+import com.stevanrose.carbon_two.office.controller.OfficeController;
 import com.stevanrose.carbon_two.office.domain.Office;
 import com.stevanrose.carbon_two.office.service.OfficeService;
 import com.stevanrose.carbon_two.office.web.dto.OfficeRequest;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = OfficeController.class)
-class OfficeControllerWebTest {
+class OfficeControllerCreateWebTest {
 
     @Autowired
     MockMvc mvc;
@@ -47,12 +48,7 @@ class OfficeControllerWebTest {
                   }
                 """;
 
-        var entity = Office.builder()
-                .id(UUID.randomUUID())
-                .code("LON-01")
-                .name("London HQ")
-                .gridRegionCode("GB-LDN")
-                .build();
+        var entity = Office.builder().id(UUID.randomUUID()).code("LON-01").name("London HQ").gridRegionCode("GB-LDN").build();
 
         var resp = new OfficeResponse();
         resp.setId(entity.getId());
@@ -62,8 +58,8 @@ class OfficeControllerWebTest {
         when(officeMapper.toResponse(entity)).thenReturn(resp);
 
         mvc.perform(post("/api/offices")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(reqJson))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reqJson))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", Matchers.matchesRegex(".*/api/offices/.+")))
                 .andExpect(jsonPath("$.id").value(entity.getId().toString()));

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerListWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerListWebTest.java
@@ -1,0 +1,85 @@
+package com.stevanrose.carbon_two.office.controller.slice;
+
+import com.stevanrose.carbon_two.office.controller.OfficeController;
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.office.service.OfficeService;
+import com.stevanrose.carbon_two.office.web.dto.mapper.OfficeMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = OfficeController.class)
+class OfficeControllerListWebTest {
+
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    OfficeService officeService;
+    @Autowired
+    OfficeMapper officeMapper;
+
+    @SneakyThrows
+    @Test
+    void should_list_offices_with_pagination() {
+
+        var office1 = Office.builder().id(UUID.randomUUID()).code("LON-01").name("London HQ").gridRegionCode("GB-LDN").build();
+
+        PageRequest req = PageRequest.of(0, 1);
+        Page<Office> page = new PageImpl<>(List.of(office1), req, 2L);
+
+        when(officeService.list(any())).thenReturn(page);
+
+        mvc.perform(get("/api/offices")
+                        .param("page", "0")
+                        .param("size", "1")
+                        .param("sort", "name,asc")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].id", notNullValue()))
+                .andExpect(jsonPath("$.content[0].code").value("LON-01"))
+                .andExpect(jsonPath("$.content[0].name").value("London HQ"))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.size").value(1))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.totalPages").value(2));
+
+    }
+
+    @TestConfiguration
+    static class MockConfig {
+
+        @Bean
+        OfficeService officeService() {
+            return mock(OfficeService.class);
+        }
+
+        @Bean
+        OfficeMapper officeMapper() {
+            return Mappers.getMapper(OfficeMapper.class);
+        }
+    }
+
+}


### PR DESCRIPTION
Summary

- Implemented GET /api/offices endpoint returning a paginated, sortable list of offices.
- Integrated Spring Data’s Pageable and Sort support for flexible client-side pagination and ordering.
- Introduced PageResponse<T> wrapper to provide a stable JSON contract (page, size, totalElements, totalPages).
- Added OpenAPI documentation with a concrete OfficePageResponse schema for clear Swagger representation.
- Extended OfficeService to delegate pageable queries to OfficeRepository.
- Created focused web-slice test verifying controller behavior, JSON structure, and pagination metadata.
- Added integration test ensuring persistence, pagination, and sorting correctness against the database.

Notes

- Establishes the foundation for consistent pagination patterns across future endpoints.
- Removes Springdoc warnings about unstable Page JSON.
- Demonstrates layered architecture, clean DTO mapping, and contract-first API design.