### PR TITLE
feature(office): add Delete Office endpoint with 404/409 handling and…

### DIFF
--- a/src/main/java/com/stevanrose/carbon_two/common/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/stevanrose/carbon_two/common/errors/GlobalExceptionHandler.java
@@ -15,5 +15,11 @@ public class GlobalExceptionHandler {
     return new ErrorBody("NOT_FOUND", ex.getMessage());
   }
 
+  @ExceptionHandler(IllegalStateException.class)
+  @ResponseStatus(HttpStatus.CONFLICT)
+  public ErrorBody handleConflict(IllegalStateException ex) {
+    return new ErrorBody("CONFLICT", ex.getMessage());
+  }
+
   public record ErrorBody(String code, String message) {}
 }

--- a/src/main/java/com/stevanrose/carbon_two/office/controller/OfficeController.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/controller/OfficeController.java
@@ -93,6 +93,15 @@ public class OfficeController {
 
   @PutMapping("/{id}")
   @Operation(summary = "Update an office (full)")
+  @ApiResponse(responseCode = "200", description = "Office updated successfully")
+  @ApiResponse(
+      responseCode = "400",
+      description = "Invalid input",
+      content = @Content(schema = @Schema(implementation = Void.class)))
+  @ApiResponse(
+      responseCode = "404",
+      description = "Office not found",
+      content = @Content(schema = @Schema(implementation = Void.class)))
   public OfficeResponse put(@PathVariable UUID id, @Valid @RequestBody OfficeRequest body) {
     OfficeUpdateRequest update = new OfficeUpdateRequest();
     update.setCode(body.getCode());
@@ -102,5 +111,22 @@ public class OfficeController {
     update.setFloorAreaM2(body.getFloorAreaM2());
 
     return officeMapper.toResponse(officeService.update(id, update));
+  }
+
+  @DeleteMapping("/{id}")
+  @Operation(
+      summary = "Delete an office by ID",
+      description = "Delete a specific office by its ID.")
+  @ApiResponse(
+      responseCode = "204",
+      description = "Office deleted successfully",
+      content = @Content)
+  @ApiResponse(
+      responseCode = "404",
+      description = "Office not found",
+      content = @Content(schema = @Schema(implementation = Void.class)))
+  public ResponseEntity<Void> deleteOffice(@PathVariable UUID id) {
+    officeService.delete(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/stevanrose/carbon_two/office/service/OfficeService.java
+++ b/src/main/java/com/stevanrose/carbon_two/office/service/OfficeService.java
@@ -7,6 +7,7 @@ import com.stevanrose.carbon_two.office.web.dto.mapper.OfficeMapper;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -59,5 +60,18 @@ public class OfficeService {
     }
 
     return officeRepository.save(entity);
+  }
+
+  @Transactional
+  public void delete(UUID id) {
+    if (!officeRepository.existsById(id)) {
+      throw new EntityNotFoundException("Office not found with id: " + id);
+    }
+    try {
+      officeRepository.deleteById(id);
+      officeRepository.flush();
+    } catch (DataIntegrityViolationException ex) {
+      throw new IllegalStateException("Office cannot be deleted due to existing references", ex);
+    }
   }
 }

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerCreateIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerCreateIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.stevanrose.carbon_two.office.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stevanrose.carbon_two.office.repository.OfficeRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OfficeControllerCreateIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private OfficeRepository officeRepository;
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    officeRepository.deleteAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void should_create_office() {
+
+    String reqJson =
+        """
+                    {
+                      "code": "LON-01",
+                      "name": "London HQ",
+                      "address": "10 Downing Street",
+                      "gridRegionCode": "GB-LDN",
+                      "floorAreaM2": 300.0
+                    }
+                """;
+
+    mvc.perform(post("/api/offices").contentType("application/json").content(reqJson))
+        .andExpect(status().isCreated());
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerDeleteIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerDeleteIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.stevanrose.carbon_two.office.controller.integration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.office.repository.OfficeRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OfficeControllerDeleteIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private OfficeRepository officeRepository;
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    officeRepository.deleteAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void should_delete_office() {
+
+    var office =
+        officeRepository.save(
+            Office.builder()
+                .code("LON-01")
+                .name("London HQ")
+                .address("10 Downing Street")
+                .gridRegionCode("GB-LDN")
+                .floorAreaM2(2500.00)
+                .build());
+
+    mvc.perform(delete("/api/offices/{id}", office.getId())).andExpect(status().isNoContent());
+
+    assertTrue(officeRepository.findById(office.getId()).isEmpty());
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerFindOneIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerFindOneIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.stevanrose.carbon_two.office.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.office.repository.OfficeRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OfficeControllerFindOneIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private OfficeRepository officeRepository;
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    officeRepository.deleteAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void should_find_one_office_entity_and_return_ok() {
+    Office office =
+        officeRepository.save(
+            Office.builder()
+                .code("LON-01")
+                .name("London HQ")
+                .address("10 Downing Street")
+                .gridRegionCode("GB-LDN")
+                .floorAreaM2(300.0)
+                .build());
+
+    mvc.perform(get("/api/offices/{id}", office.getId()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(office.getId().toString()))
+        .andExpect(jsonPath("$.code").value("LON-01"))
+        .andExpect(jsonPath("$.name").value("London HQ"))
+        .andExpect(jsonPath("$.address").value("10 Downing Street"))
+        .andExpect(jsonPath("$.gridRegionCode").value("GB-LDN"))
+        .andExpect(jsonPath("$.floorAreaM2").value(300.0));
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerListIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerListIntegrationTest.java
@@ -1,0 +1,58 @@
+package com.stevanrose.carbon_two.office.controller.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.office.repository.OfficeRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OfficeControllerListIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private OfficeRepository officeRepository;
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    officeRepository.deleteAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void should_list_offices_with_pagination() {
+    Office office1 =
+        Office.builder()
+            .code("LON-01")
+            .name("London HQ")
+            .address("10 Downing Street")
+            .gridRegionCode("GB-LDN")
+            .floorAreaM2(300.0)
+            .build();
+
+    officeRepository.save(office1);
+
+    mvc.perform(
+            get("/api/offices")
+                .param("page", "0")
+                .param("size", "1")
+                .param("sort", "name,asc")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isArray())
+        .andExpect(jsonPath("$.content[0].code").value("LON-01"))
+        .andExpect(jsonPath("$.content[0].name").value("London HQ"));
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerUpdateIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/integration/OfficeControllerUpdateIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.stevanrose.carbon_two.office.controller;
+package com.stevanrose.carbon_two.office.controller.integration;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -19,7 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class OfficeControllerTest {
+class OfficeControllerUpdateIntegrationTest {
 
   @Autowired private MockMvc mvc;
 
@@ -29,74 +29,6 @@ class OfficeControllerTest {
   @BeforeEach
   void setUp() {
     officeRepository.deleteAll();
-  }
-
-  @SneakyThrows
-  @Test
-  void should_find_one_office_entity_and_return_ok() {
-    Office office =
-        officeRepository.save(
-            Office.builder()
-                .code("LON-01")
-                .name("London HQ")
-                .address("10 Downing Street")
-                .gridRegionCode("GB-LDN")
-                .floorAreaM2(300.0)
-                .build());
-
-    mvc.perform(get("/api/offices/{id}", office.getId()))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.id").value(office.getId().toString()))
-        .andExpect(jsonPath("$.code").value("LON-01"))
-        .andExpect(jsonPath("$.name").value("London HQ"))
-        .andExpect(jsonPath("$.address").value("10 Downing Street"))
-        .andExpect(jsonPath("$.gridRegionCode").value("GB-LDN"))
-        .andExpect(jsonPath("$.floorAreaM2").value(300.0));
-  }
-
-  @SneakyThrows
-  @Test
-  void should_list_offices_with_pagination() {
-    Office office1 =
-        Office.builder()
-            .code("LON-01")
-            .name("London HQ")
-            .address("10 Downing Street")
-            .gridRegionCode("GB-LDN")
-            .floorAreaM2(300.0)
-            .build();
-
-    officeRepository.save(office1);
-
-    mvc.perform(
-            get("/api/offices")
-                .param("page", "0")
-                .param("size", "1")
-                .param("sort", "name,asc")
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.content").isArray())
-        .andExpect(jsonPath("$.content[0].code").value("LON-01"))
-        .andExpect(jsonPath("$.content[0].name").value("London HQ"));
-  }
-
-  @SneakyThrows
-  @Test
-  void should_create_office() {
-
-    String reqJson =
-        """
-                    {
-                      "code": "LON-01",
-                      "name": "London HQ",
-                      "address": "10 Downing Street",
-                      "gridRegionCode": "GB-LDN",
-                      "floorAreaM2": 300.0
-                    }
-                """;
-
-    mvc.perform(post("/api/offices").contentType("application/json").content(reqJson))
-        .andExpect(status().isCreated());
   }
 
   @SneakyThrows

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerDeleteWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerDeleteWebTest.java
@@ -1,0 +1,83 @@
+package com.stevanrose.carbon_two.office.controller.slice;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.stevanrose.carbon_two.common.errors.GlobalExceptionHandler;
+import com.stevanrose.carbon_two.office.controller.OfficeController;
+import com.stevanrose.carbon_two.office.service.OfficeService;
+import com.stevanrose.carbon_two.office.web.dto.mapper.OfficeMapper;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = OfficeController.class)
+class OfficeControllerDeleteWebTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired OfficeService officeService;
+  @Autowired OfficeMapper officeMapper;
+
+  @SneakyThrows
+  @Test
+  void should_delete_office_and_return_deleted() {
+
+    UUID id = UUID.randomUUID();
+    mvc.perform(delete("/api/offices/{id}", id)).andExpect(status().isNoContent());
+    verify(officeService).delete(id);
+  }
+
+  @SneakyThrows
+  @Test
+  void should_return_not_found_when_id_does_not_exist() {
+
+    UUID id = UUID.randomUUID();
+    doThrow(new EntityNotFoundException("Office not found with id: " + id))
+        .when(officeService)
+        .delete(id);
+    mvc.perform(delete("/api/offices/{id}", id))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @SneakyThrows
+  @Test
+  void should_return_conflict_when_references_exist() {
+
+    UUID id = UUID.randomUUID();
+    doThrow(new IllegalStateException("Cannot delete office with existing references"))
+        .when(officeService)
+        .delete(id);
+
+    mvc.perform(delete("/api/offices/{id}", id))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("CONFLICT"));
+  }
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    OfficeService officeService() {
+      return mock(OfficeService.class);
+    }
+
+    @Bean
+    OfficeMapper officeMapper() {
+      return Mappers.getMapper(OfficeMapper.class);
+    }
+
+    @Bean
+    GlobalExceptionHandler globalExceptionHandler() {
+      return new GlobalExceptionHandler();
+    }
+  }
+}


### PR DESCRIPTION
… web-slice tests

Summary

- Implemented DELETE /api/offices/{id} returning 204 on success.
- EntityNotFoundException mapped to 404; FK violations mapped to 409.
- Added focused @WebMvcTest suite: happy path, not-found, conflict.
- Ensured immediate constraint surfacing via flush() after delete.