### PR TITLE
feature(energy): list OfficeEnergyStatements by officeId with paginat…

### DIFF
--- a/src/main/java/com/stevanrose/carbon_two/officeenergystatement/controller/OfficeEnergyStatementController.java
+++ b/src/main/java/com/stevanrose/carbon_two/officeenergystatement/controller/OfficeEnergyStatementController.java
@@ -1,5 +1,6 @@
 package com.stevanrose.carbon_two.officeenergystatement.controller;
 
+import com.stevanrose.carbon_two.common.paging.PageResponse;
 import com.stevanrose.carbon_two.officeenergystatement.service.OfficeEnergyStatementService;
 import com.stevanrose.carbon_two.officeenergystatement.web.dto.OfficeEnergyStatementRequest;
 import com.stevanrose.carbon_two.officeenergystatement.web.dto.OfficeEnergyStatementResponse;
@@ -9,6 +10,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +28,27 @@ public class OfficeEnergyStatementController {
 
   private final OfficeEnergyStatementService service;
   private final OfficeEnergyStatementMapper mapper;
+
+  @GetMapping
+  @Operation(summary = "List office energy statements")
+  @ApiResponse(responseCode = "200", description = "List of office energy statements retrieved")
+  @ApiResponse(responseCode = "404", description = "Office not found")
+  @ApiResponse(responseCode = "500", description = "Internal server error")
+  public PageResponse<OfficeEnergyStatementResponse> listByOfficeId(
+      @PathVariable UUID officeId,
+      @ParameterObject
+          @PageableDefault(size = 20)
+          @SortDefault.SortDefaults({
+            @SortDefault(sort = "year", direction = Sort.Direction.DESC),
+            @SortDefault(sort = "month", direction = Sort.Direction.DESC)
+          })
+          Pageable pageable) {
+
+    Page<OfficeEnergyStatementResponse> page =
+        service.listByOfficeId(officeId, pageable).map(mapper::toResponse);
+
+    return PageResponse.of(page);
+  }
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/stevanrose/carbon_two/officeenergystatement/repository/OfficeEnergyStatementRepository.java
+++ b/src/main/java/com/stevanrose/carbon_two/officeenergystatement/repository/OfficeEnergyStatementRepository.java
@@ -2,10 +2,14 @@ package com.stevanrose.carbon_two.officeenergystatement.repository;
 
 import com.stevanrose.carbon_two.officeenergystatement.domain.OfficeEnergyStatement;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OfficeEnergyStatementRepository
     extends JpaRepository<OfficeEnergyStatement, UUID> {
 
   boolean existsByOfficeIdAndYearAndMonth(UUID officeId, Integer year, Integer month);
+
+  Page<OfficeEnergyStatement> findByOfficeId(UUID officeId, Pageable pageable);
 }

--- a/src/main/java/com/stevanrose/carbon_two/officeenergystatement/service/OfficeEnergyStatementService.java
+++ b/src/main/java/com/stevanrose/carbon_two/officeenergystatement/service/OfficeEnergyStatementService.java
@@ -8,6 +8,8 @@ import com.stevanrose.carbon_two.officeenergystatement.web.dto.mapper.OfficeEner
 import jakarta.persistence.EntityNotFoundException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,16 @@ public class OfficeEnergyStatementService {
   private final OfficeRepository officeRepository;
   private final OfficeEnergyStatementRepository officeEnergyStatementRepository;
   private final OfficeEnergyStatementMapper officeEnergyStatementMapper;
+
+  @Transactional(readOnly = true)
+  public Page<OfficeEnergyStatement> listByOfficeId(UUID officeId, Pageable pageable) {
+
+    if (!officeRepository.existsById(officeId)) {
+      throw new EntityNotFoundException("Office not found with id: " + officeId);
+    }
+
+    return officeEnergyStatementRepository.findByOfficeId(officeId, pageable);
+  }
 
   @Transactional
   public OfficeEnergyStatement create(UUID officeId, OfficeEnergyStatementRequest request) {

--- a/src/test/java/com/stevanrose/carbon_two/officeenergystatement/controller/slice/OfficeEnergyStatementControllerListWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/officeenergystatement/controller/slice/OfficeEnergyStatementControllerListWebTest.java
@@ -1,0 +1,89 @@
+package com.stevanrose.carbon_two.officeenergystatement.controller.slice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.officeenergystatement.controller.OfficeEnergyStatementController;
+import com.stevanrose.carbon_two.officeenergystatement.domain.OfficeEnergyStatement;
+import com.stevanrose.carbon_two.officeenergystatement.service.OfficeEnergyStatementService;
+import com.stevanrose.carbon_two.officeenergystatement.web.dto.mapper.OfficeEnergyStatementMapper;
+import java.util.List;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = OfficeEnergyStatementController.class)
+class OfficeEnergyStatementControllerListWebTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired OfficeEnergyStatementService service;
+
+  @SneakyThrows
+  @Test
+  void should_list_office_energy_statement_and_return_ok() {
+
+    UUID officeId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
+
+    var entity =
+        OfficeEnergyStatement.builder()
+            .id(id)
+            .office(Office.builder().id(officeId).build())
+            .year(2025)
+            .month(10)
+            .electricityKwh(1234.0)
+            .build();
+
+    PageRequest req =
+        PageRequest.of(0, 1, Sort.by("year").descending().and(Sort.by("month").descending()));
+    Page<OfficeEnergyStatement> page = new PageImpl<>(List.of(entity), req, 2);
+
+    when(service.listByOfficeId(any(UUID.class), any(PageRequest.class))).thenReturn(page);
+
+    mvc.perform(
+            get("/api/offices/{officeId}/energy-statements", officeId)
+                .param("page", "0")
+                .param("size", "1")
+                .param("sort", "year,desc")
+                .param("sort", "month,desc")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value(id.toString()))
+        .andExpect(jsonPath("$.content[0].officeId").value(officeId.toString()))
+        .andExpect(jsonPath("$.content[0].year").value(2025))
+        .andExpect(jsonPath("$.content[0].month").value(10))
+        .andExpect(jsonPath("$.page").value(0))
+        .andExpect(jsonPath("$.size").value(1))
+        .andExpect(jsonPath("$.totalElements").value(2))
+        .andExpect(jsonPath("$.totalPages").value(2));
+  }
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    OfficeEnergyStatementService service() {
+      return mock(OfficeEnergyStatementService.class);
+    }
+
+    @Bean
+    OfficeEnergyStatementMapper mapper() {
+      return Mappers.getMapper(OfficeEnergyStatementMapper.class);
+    }
+  }
+}


### PR DESCRIPTION
…ion & sorting

Summary

- Added GET /api/offices/{officeId}/energy-statements endpoint returning paginated, sortable history.
- Service method delegates to repository findByOffice_Id(…, Pageable).
- Returned stable PageResponse<OfficeEnergyStatementResponse> JSON structure.
- Added @WebMvcTest slice verifying payload and pagination metadata.
- Default sort set to year,month descending for recent-first history.