### PR TITLE
feature(energy): idempotent upsert by year/month for EnergyStatement

### DIFF
--- a/src/main/java/com/stevanrose/carbon_two/energystatement/controller/EnergyStatementController.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/controller/EnergyStatementController.java
@@ -85,4 +85,31 @@ public class EnergyStatementController {
             .toUri();
     return ResponseEntity.created(location).body(body);
   }
+
+  @PutMapping("/{year}/{month}")
+  @Operation(summary = "Upsert an office energy statement")
+  @ApiResponse(responseCode = "200", description = "Office energy statement upserted successfully")
+  @ApiResponse(responseCode = "400", description = "Invalid input data")
+  @ApiResponse(responseCode = "404", description = "Office not found")
+  @ApiResponse(responseCode = "500", description = "Internal server error")
+  public ResponseEntity<EnergyStatementResponse> upsert(
+      @PathVariable UUID officeId,
+      @PathVariable int year,
+      @PathVariable int month,
+      @Valid @RequestBody EnergyStatementRequest request,
+      UriComponentsBuilder uri) {
+
+    var result = service.upsert(officeId, year, month, request);
+    var body = mapper.toResponse(result.entity());
+
+    if (result.created()) {
+      var location =
+          uri.path("/api/offices/{officeId}/energy-statements/{id}")
+              .buildAndExpand(officeId, result.entity().getId())
+              .toUri();
+      return ResponseEntity.created(location).body(body);
+    } else {
+      return ResponseEntity.ok(body);
+    }
+  }
 }

--- a/src/main/java/com/stevanrose/carbon_two/energystatement/repository/EnergyStatementRepository.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/repository/EnergyStatementRepository.java
@@ -14,4 +14,7 @@ public interface EnergyStatementRepository extends JpaRepository<EnergyStatement
   Page<EnergyStatement> findByOfficeId(UUID officeId, Pageable pageable);
 
   Optional<EnergyStatement> findByIdAndOfficeId(UUID id, UUID officeId);
+
+  Optional<EnergyStatement> findByOfficeIdAndYearAndMonth(
+      UUID officeId, Integer year, Integer month);
 }

--- a/src/main/java/com/stevanrose/carbon_two/energystatement/web/dto/mapper/EnergyStatementMapper.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/web/dto/mapper/EnergyStatementMapper.java
@@ -6,6 +6,7 @@ import com.stevanrose.carbon_two.energystatement.web.dto.EnergyStatementResponse
 import com.stevanrose.carbon_two.office.domain.Office;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface EnergyStatementMapper {
@@ -18,4 +19,6 @@ public interface EnergyStatementMapper {
 
   @Mapping(target = "officeId", source = "office.id")
   EnergyStatementResponse toResponse(EnergyStatement entity);
+
+  void update(@MappingTarget EnergyStatement target, EnergyStatementRequest request);
 }

--- a/src/main/resources/db/changelog/000-extensions.json
+++ b/src/main/resources/db/changelog/000-extensions.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "ext-uuid-ossp",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "sql": {

--- a/src/main/resources/db/changelog/100-enum-commutemode.json
+++ b/src/main/resources/db/changelog/100-enum-commutemode.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "enum-commutemode",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "sql": {

--- a/src/main/resources/db/changelog/100-enum-employmenttype.json
+++ b/src/main/resources/db/changelog/100-enum-employmenttype.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "enum-employmenttype",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "sql": {

--- a/src/main/resources/db/changelog/100-enum-heatingfueltype.json
+++ b/src/main/resources/db/changelog/100-enum-heatingfueltype.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "enum-heatingfueltype",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "sql": {

--- a/src/main/resources/db/changelog/100-enum-workpattern.json
+++ b/src/main/resources/db/changelog/100-enum-workpattern.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "enum-workpattern",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "sql": {

--- a/src/main/resources/db/changelog/200-table-CommuteSurvey.json
+++ b/src/main/resources/db/changelog/200-table-CommuteSurvey.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "table-CommuteSurvey",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/changelog/200-table-Employee.json
+++ b/src/main/resources/db/changelog/200-table-Employee.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "table-Employee",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/changelog/200-table-Office.json
+++ b/src/main/resources/db/changelog/200-table-Office.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "table-Office",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/changelog/200-table-OfficeEnergyStatement.json
+++ b/src/main/resources/db/changelog/200-table-OfficeEnergyStatement.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "table-OfficeEnergyStatement",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "createTable": {

--- a/src/main/resources/db/changelog/300-foreign-keys.json
+++ b/src/main/resources/db/changelog/300-foreign-keys.json
@@ -3,7 +3,7 @@
     {
       "changeSet": {
         "id": "foreign-keys",
-        "author": "handwritten",
+        "author": "Steve Rose",
         "changes": [
           {
             "addForeignKeyConstraint": {

--- a/src/main/resources/db/changelog/400-uq-energy-statement-office-year-month.json
+++ b/src/main/resources/db/changelog/400-uq-energy-statement-office-year-month.json
@@ -1,0 +1,19 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "uq_officeenergystatement_office_year_month",
+        "author": "Steve Rose",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "tableName": "OfficeEnergyStatement",
+              "columnNames": "officeId, year, month",
+              "constraintName": "uq_officeenergystatement_office_year_month"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/db/changelog/changelog-master.json
+++ b/src/main/resources/db/changelog/changelog-master.json
@@ -49,6 +49,11 @@
       "include": {
         "file": "db/changelog/300-foreign-keys.json"
       }
+    },
+    {
+      "include": {
+        "file": "db/changelog/400-uq-energy-statement-office-year-month.json"
+      }
     }
   ]
 }

--- a/src/test/java/com/stevanrose/carbon_two/energystatement/controller/slice/EnergyStatementControllerUpsertWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/energystatement/controller/slice/EnergyStatementControllerUpsertWebTest.java
@@ -1,0 +1,120 @@
+package com.stevanrose.carbon_two.energystatement.controller.slice;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.stevanrose.carbon_two.energystatement.controller.EnergyStatementController;
+import com.stevanrose.carbon_two.energystatement.domain.EnergyStatement;
+import com.stevanrose.carbon_two.energystatement.domain.HeatingFuelType;
+import com.stevanrose.carbon_two.energystatement.service.EnergyStatementService;
+import com.stevanrose.carbon_two.energystatement.web.dto.mapper.EnergyStatementMapper;
+import com.stevanrose.carbon_two.office.domain.Office;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = EnergyStatementController.class)
+class EnergyStatementControllerUpsertWebTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired EnergyStatementService service;
+
+  @SneakyThrows
+  @Test
+  void should_create_energy_statement_and_return_created() {
+
+    UUID officeId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
+    var entity =
+        EnergyStatement.builder()
+            .id(id)
+            .office(Office.builder().id(officeId).build())
+            .year(2025)
+            .month(10)
+            .electricityKwh(1234.0)
+            .heatingFuelType(HeatingFuelType.NONE)
+            .build();
+
+    when(service.upsert(eq(officeId), eq(2025), eq(10), any()))
+        .thenReturn(new EnergyStatementService.UpsertResult(entity, true));
+
+    var json =
+        """
+          {"year":2025,"month":10,"electricityKwh":1000.0,"heatingFuelType":"NONE"}
+        """;
+
+    mvc.perform(
+            put("/api/offices/{officeId}/energy-statements/{year}/{month}", officeId, 2025, 10)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+        .andExpect(status().isCreated())
+        .andExpect(
+            header()
+                .string(
+                    "Location",
+                    org.hamcrest.Matchers.containsString(
+                        "/api/offices/" + officeId + "/energy-statements/" + id)))
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.year").value(2025))
+        .andExpect(jsonPath("$.month").value(10));
+  }
+
+  @SneakyThrows
+  @Test
+  void should_update_energy_statement_and_return_ok() {
+
+    UUID officeId = UUID.randomUUID();
+    UUID id = UUID.randomUUID();
+    var entity =
+        EnergyStatement.builder()
+            .id(id)
+            .office(Office.builder().id(officeId).build())
+            .year(2025)
+            .month(10)
+            .electricityKwh(1500.0)
+            .heatingFuelType(HeatingFuelType.GAS)
+            .build();
+
+    when(service.upsert(eq(officeId), eq(2025), eq(10), any()))
+        .thenReturn(new EnergyStatementService.UpsertResult(entity, false));
+
+    var json =
+        """
+          {"year":2025,"month":10,"electricityKwh":1500.0,"heatingFuelType":"GAS"}
+        """;
+
+    mvc.perform(
+            put("/api/offices/{officeId}/energy-statements/{year}/{month}", officeId, 2025, 10)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.electricityKwh").value(1500.0))
+        .andExpect(jsonPath("$.heatingFuelType").value("GAS"));
+  }
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    EnergyStatementService service() {
+      return mock(EnergyStatementService.class);
+    }
+
+    @Bean
+    EnergyStatementMapper mapper() {
+      return Mappers.getMapper(EnergyStatementMapper.class);
+    }
+  }
+}


### PR DESCRIPTION
Summary

- Added PUT /api/offices/{officeId}/energy-statements/{year}/{month} to create or update statements idempotently.
- Service resolves natural key (officeId, year, month) and updates in-place when present.
- Returns 201 Created with Location for creations; 200 OK for updates.
- Mapper supports in-place updates via update(@MappingTarget, dto).
- Added controller-slice tests for both create and update paths.
- DB unique constraint on (officeId, year, month) to enforce the natural key.