### PR TITLE
feat(energy): delete energy statement by (officeId, year, month) with…

### DIFF
--- a/src/main/java/com/stevanrose/carbon_two/energystatement/controller/EnergyStatementController.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/controller/EnergyStatementController.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -86,5 +87,16 @@ public class EnergyStatementController {
     } else {
       return ResponseEntity.ok(body);
     }
+  }
+
+  @DeleteMapping("/{year}/{month}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @Operation(summary = "Delete an office energy statement")
+  @ApiResponse(responseCode = "204", description = "Office energy statement deleted successfully")
+  @ApiResponse(responseCode = "404", description = "Office or energy statement not found")
+  @ApiResponse(responseCode = "500", description = "Internal server error")
+  public void deleteByOfficeIdAndYearAndMonth(
+      @PathVariable UUID officeId, @PathVariable int year, @PathVariable int month) {
+    service.deleteByOfficeIdAndYearAndMonth(officeId, year, month);
   }
 }

--- a/src/main/java/com/stevanrose/carbon_two/energystatement/repository/EnergyStatementRepository.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/repository/EnergyStatementRepository.java
@@ -17,4 +17,6 @@ public interface EnergyStatementRepository extends JpaRepository<EnergyStatement
 
   Optional<EnergyStatement> findByOfficeIdAndYearAndMonth(
       UUID officeId, Integer year, Integer month);
+
+  long deleteByOfficeIdAndYearAndMonth(UUID officeId, Integer year, Integer month);
 }

--- a/src/main/java/com/stevanrose/carbon_two/energystatement/service/EnergyStatementService.java
+++ b/src/main/java/com/stevanrose/carbon_two/energystatement/service/EnergyStatementService.java
@@ -67,4 +67,18 @@ public class EnergyStatementService {
       return new UpsertResult(saved, true);
     }
   }
+
+  @Transactional
+  public void deleteByOfficeIdAndYearAndMonth(UUID officeId, int year, int month) {
+    long removed = energyStatementRepository.deleteByOfficeIdAndYearAndMonth(officeId, year, month);
+    if (removed == 0) {
+      throw new EntityNotFoundException(
+          "Energy statement not found for office id: "
+              + officeId
+              + ", year: "
+              + year
+              + ", month: "
+              + month);
+    }
+  }
 }

--- a/src/test/java/com/stevanrose/carbon_two/energystatement/controller/integration/EnergyStatementControllerDeleteIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/energystatement/controller/integration/EnergyStatementControllerDeleteIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.stevanrose.carbon_two.energystatement.controller.integration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stevanrose.carbon_two.energystatement.domain.EnergyStatement;
+import com.stevanrose.carbon_two.energystatement.domain.HeatingFuelType;
+import com.stevanrose.carbon_two.energystatement.repository.EnergyStatementRepository;
+import com.stevanrose.carbon_two.office.domain.Office;
+import com.stevanrose.carbon_two.office.repository.OfficeRepository;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class EnergyStatementControllerDeleteIntegrationTest {
+
+  @Autowired private MockMvc mvc;
+
+  @Autowired private OfficeRepository officeRepository;
+  @Autowired private EnergyStatementRepository energyStatementRepository;
+  @Autowired private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    energyStatementRepository.deleteAll();
+    officeRepository.deleteAll();
+  }
+
+  @SneakyThrows
+  @Test
+  void should_delete_energy_statement_and_return_no_content() {
+
+    var office =
+        officeRepository.save(
+            Office.builder().code("ENG-01").name("Engineering").gridRegionCode("GB-LDN").build());
+
+    energyStatementRepository.save(
+        EnergyStatement.builder()
+            .office(office)
+            .year(2025)
+            .month(10)
+            .electricityKwh(1000.0)
+            .heatingFuelType(HeatingFuelType.NONE)
+            .build());
+
+    mvc.perform(
+            delete(
+                "/api/offices/{officeId}/energy-statements/{year}/{month}",
+                office.getId(),
+                2025,
+                10))
+        .andExpect(status().isNoContent());
+
+    assertTrue(
+        energyStatementRepository
+            .findByOfficeIdAndYearAndMonth(office.getId(), 2025, 10)
+            .isEmpty());
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/energystatement/controller/slice/EnergyStatementControllerDeleteWebTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/energystatement/controller/slice/EnergyStatementControllerDeleteWebTest.java
@@ -1,0 +1,66 @@
+package com.stevanrose.carbon_two.energystatement.controller.slice;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.stevanrose.carbon_two.energystatement.controller.EnergyStatementController;
+import com.stevanrose.carbon_two.energystatement.service.EnergyStatementService;
+import com.stevanrose.carbon_two.energystatement.web.dto.mapper.EnergyStatementMapper;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = EnergyStatementController.class)
+class EnergyStatementControllerDeleteWebTest {
+
+  @Autowired MockMvc mvc;
+  @Autowired EnergyStatementService service;
+
+  @SneakyThrows
+  @Test
+  void should_delete_energy_statement_and_return_no_content() {
+
+    UUID officeId = UUID.randomUUID();
+
+    mvc.perform(
+            delete("/api/offices/{officeId}/energy-statements/{year}/{month}", officeId, 2025, 10))
+        .andExpect(status().isNoContent());
+  }
+
+  @SneakyThrows
+  @Test
+  void should_not_find_energy_statement_and_return_not_found() {
+    UUID officeId = UUID.randomUUID();
+
+    doThrow(new EntityNotFoundException("Energy statement not found"))
+        .when(service)
+        .deleteByOfficeIdAndYearAndMonth(officeId, 2025, 10);
+
+    mvc.perform(
+            delete("/api/offices/{officeId}/energy-statements/{year}/{month}", officeId, 2025, 10))
+        .andExpect(status().isNotFound());
+  }
+
+  @TestConfiguration
+  static class MockConfig {
+
+    @Bean
+    EnergyStatementService service() {
+      return mock(EnergyStatementService.class);
+    }
+
+    @Bean
+    EnergyStatementMapper mapper() {
+      return Mappers.getMapper(EnergyStatementMapper.class);
+    }
+  }
+}


### PR DESCRIPTION
… 204/404 semantics

Summary

- Implemented DELETE /api/offices/{officeId}/energy-statements/{year}/{month}.
- Fast, atomic deletion using deleteByOffice_IdAndYearAndMonth with 404 if not found.
- Added controller-slice tests for success (204) and not found (404).
- Reused global exception handler for consistent error payloads.