### PR TITLE
refactor(slice-tests): convert DTOs to Java records

### DIFF
--- a/src/test/java/com/stevanrose/carbon_two/common/controller/integration/BaseControllerIntegrationTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/common/controller/integration/BaseControllerIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.stevanrose.carbon_two.common.controller.integration;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stevanrose.carbon_two.common.controller.slice.BaseControllerTest;
 import com.stevanrose.carbon_two.common.support.PostgresContainerSingleton;

--- a/src/test/java/com/stevanrose/carbon_two/dates/DatesTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/dates/DatesTest.java
@@ -1,0 +1,42 @@
+package com.stevanrose.carbon_two.dates;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class DatesTest {
+
+  @Test
+  void date() {
+
+    Date date = new Date();
+    log.info("java.util.Date: {}", date);
+
+    LocalDateTime localDateTime = LocalDateTime.now();
+    log.info("java.time.LocalDateTime: {}", localDateTime);
+  }
+
+  @Test
+  void dateConvertToLocalDateTime() {
+    Date date = new Date();
+    log.info("java.util.Date: {}", date);
+    LocalDateTime localDateTime =
+        date.toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDateTime();
+    log.info("Converted java.util.Date to java.time.LocalDateTime: {}", localDateTime);
+    Date backToDate = Date.from(localDateTime.atZone(java.time.ZoneId.systemDefault()).toInstant());
+    log.info("Converted back to java.util.Date: {}", backToDate);
+  }
+
+  @Test
+  void dateToOffsetDateTime() {
+    Date date = new Date();
+    log.info("java.util.Date: {}", date);
+    OffsetDateTime offsetDateTime = date.toInstant().atOffset(java.time.ZoneOffset.UTC);
+    log.info("Converted java.util.Date to java.time.OffsetDateTime: {}", offsetDateTime);
+    Date backToDate = Date.from(offsetDateTime.toInstant());
+    log.info("Converted back to java.util.Date: {}", backToDate);
+  }
+}

--- a/src/test/java/com/stevanrose/carbon_two/employee/controller/slice/EmployeeControllerTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/employee/controller/slice/EmployeeControllerTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 

--- a/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerTest.java
+++ b/src/test/java/com/stevanrose/carbon_two/office/controller/slice/OfficeControllerTest.java
@@ -34,7 +34,7 @@ import org.springframework.http.MediaType;
 
 @WebMvcTest(controllers = OfficeController.class)
 @Import(OfficeControllerTest.MockConfig.class)
-class OfficeControllerTest extends BaseControllerTest {
+class OfficeControllerTest extends   {
 
   @Autowired OfficeService officeService;
 


### PR DESCRIPTION
- Replace `EmployeeRequest` and `EmployeeUpdateRequest` classes with Java records to enforce immutability and reduce boilerplate.
- Update `EmployeeControllerTest` slice tests and mapper wiring to work with record constructors.
- Minor test cleanups; no behavioural changes.

Branch: refactor-slice-tests